### PR TITLE
Make -Q quiet

### DIFF
--- a/src/MainUtils.pas
+++ b/src/MainUtils.pas
@@ -332,6 +332,7 @@ While iParam <= Params.Count -1 do
     end
     else if id  = '-Q' then
     begin
+      FLogLevel := 0;
       OutputLog := false;
     end ;
 


### PR DESCRIPTION
-q has existed for a long time but I think has never worked.

Thsi now sets Loglevel to 0 when -q is provided.