### PR TITLE
add --PDF-NO-BITMAPMISSINGFONTS param

### DIFF
--- a/src/MainUtils.pas
+++ b/src/MainUtils.pas
@@ -67,6 +67,7 @@ type
     FIncludeDocProps: boolean;
     FKeepIRM: boolean;
     FDocStructureTags: boolean;
+    FBitmapMissingFonts: boolean;
 
 
     procedure SetCompatibilityMode(const Value: Integer);
@@ -90,6 +91,7 @@ type
     procedure SetIncludeDocProps(const Value: boolean);
     procedure SetKeepIRM(const Value: boolean);
     procedure SetDocStructureTags(const Value: boolean);
+    procedure SetBitmapMissingFonts(const Value: boolean);
 
 
   protected
@@ -185,6 +187,8 @@ type
     property IncludeDocProps : boolean read FIncludeDocProps write SetIncludeDocProps;
     property KeepIRM : boolean read FKeepIRM write SetKeepIRM; //  XPS-no-IRM
     property DocStructureTags : boolean read FDocStructureTags write SetDocStructureTags;
+    property BitmapMissingFonts : boolean read FBitmapMissingFonts write SetBitmapMissingFonts;
+
 
     property WordConstants : TResourceStrings read getWordConstants;
     property OfficeAppName : String read FOfficeAppName write FOfficeAppName;
@@ -509,6 +513,7 @@ begin
   FIncludeDocProps := true;
   FKeepIRM := true;
   FDocStructureTags := true;
+  FBitmapMissingFonts := true;
   FInputFiles := TStringList.Create;
 end;
 
@@ -1241,6 +1246,11 @@ if  (id = '-XL') or
       FKeepIRM := false;
       dec(iParam);
     end
+    else if (id = '--PDF-NO-BITMAPMISSINGFONTS') then
+    begin
+      FBitmapMissingFonts := false;
+      dec(iParam);
+    end
     else if (id = '-W') or
             (id = '--WEBHOOK') then
     begin
@@ -1555,6 +1565,11 @@ begin
   ConfigFile.Add( OfficeAppName + '_' + FormatDateTime('yyyymmdd',now) + '=' + Version);
   ConfigFile.SaveToFile(ConfigFileName);
   LogDebug('Writing Version to File:' + ConfigFileName,VERBOSE);
+end;
+
+procedure TDocumentConverter.SetBitmapMissingFonts(const Value: boolean);
+begin
+  FBitmapMissingFonts := Value;
 end;
 
 procedure TDocumentConverter.SetCompatibilityMode(const Value: Integer);

--- a/src/WordUtils.pas
+++ b/src/WordUtils.pas
@@ -277,7 +277,7 @@ begin
                    KeepIRM,//   KeepIRM:=True, _
                    BookmarkSource,//   CreateBookmarks
                    DocStructureTags,//   DocStructureTags:=True, _
-                   true,//   BitmapMissingFonts:=True,
+                   BitmapMissingFonts,//   BitmapMissingFonts:=True,
                    useISO190051 //   UseISO19005_1:=False
          );
         end else

--- a/src/res/HelpLog.txt
+++ b/src/res/HelpLog.txt
@@ -105,8 +105,11 @@ Long Parameters:
   --XPS-no-IRM
       Do not copy IRM permissions to exported XPS document.
   --PDF-No-DocStructureTags
-      Do not include DocStructureTags to help screen readers.   
-  --use-ISO190051 Create PDF to the ISO 19005-1 standard.
+      Do not include DocStructureTags to help screen readers.
+  --PDF-no-BitmapMissingFonts
+      Do not bitmap missing fonts, fonts will be substituted.   
+  --use-ISO190051 
+      Create PDF to the ISO 19005-1 standard.
 
 
 

--- a/test/test_missingfont.bat
+++ b/test/test_missingfont.bat
@@ -1,0 +1,4 @@
+REM Try optimize options on large file.
+ "../exe/docto.exe"  -f ".\Inputfiles\GEOCADx (1).docx"  -o ".\GeneratedFiles\GEOCADx_nobitmaps.pdf"   -T  wdFormatPDF --PDF-no-BitmapMissingFonts     -l 10
+ 
+ 


### PR DESCRIPTION
add --PDF-NO-BITMAPMISSINGFONTS parameter to remove fonts from pdf and substitute from machine